### PR TITLE
Assert that profile is of type `ApprovalProfile`

### DIFF
--- a/src/pabumeasures/main.py
+++ b/src/pabumeasures/main.py
@@ -2,7 +2,7 @@ from enum import Enum, auto
 
 from pabutools.election.ballot import Ballot, FrozenBallot
 from pabutools.election.instance import Instance, Project
-from pabutools.election.profile import Profile
+from pabutools.election.profile import ApprovalProfile, Profile
 from pabutools.rules import BudgetAllocation
 
 from pabumeasures import _core
@@ -20,8 +20,8 @@ def _translate_input_format(
 ) -> tuple[list[Project], list[Ballot], int, list[int], list[list[int]]]:
     if not isinstance(instance, Instance):
         raise TypeError("Instance must be of type Instance")
-    if not isinstance(profile, Profile):
-        raise TypeError("Profile must be of type Profile")
+    if not isinstance(profile, ApprovalProfile):
+        raise TypeError("Profile must be of type ApprovalProfile")
 
     projects: list[Project] = sorted(instance)
     _project_to_id = {project: i for i, project in enumerate(projects)}
@@ -43,8 +43,8 @@ def _translate_input_format_tmp(
 ) -> tuple[int, dict[str, Project], list[_core.ProjectEmbedding]]:
     if not isinstance(instance, Instance):
         raise TypeError("Instance must be of type Instance")
-    if not isinstance(profile, Profile):
-        raise TypeError("Profile must be of type Profile")
+    if not isinstance(profile, ApprovalProfile):
+        raise TypeError("Profile must be of type ApprovalProfile")
     if len([project.name for project in instance]) != len({project.name for project in instance}):
         raise ValueError("Project names must be unique in the instance")
     if any(project.cost <= 0 for project in instance):

--- a/tests/test_measures.py
+++ b/tests/test_measures.py
@@ -5,7 +5,7 @@ from utils import get_random_approval_profile, get_random_instance
 
 import pabumeasures
 
-NUMBER_OF_TIMES = 20
+NUMBER_OF_TIMES = 100
 
 
 @pytest.mark.parametrize("seed", list(range(NUMBER_OF_TIMES)))

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -10,7 +10,7 @@ from utils import get_random_approval_profile, get_random_instance
 import pabumeasures
 
 test_files = glob.glob("./data/*.pb")
-NUMBER_OF_TIMES = 0  # todo: set this to 500 when tie-breaking is implemented
+NUMBER_OF_TIMES = 100
 
 
 @pytest.mark.parametrize("file", test_files)


### PR DESCRIPTION
Assert that the profile is of type `ApprovalProfile`. I don't want to change all type signatures, since `parse_pabulib` returns `tuple[Instance, Profile]`, and doing so would cause *many* unnecessary type warnings.
