### PR TITLE
Add `cache-keys` in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,13 @@ dev = [
     "ruff>=0.12.2",
 ]
 
+[tool.uv]
+cache-keys = [
+    { file = "pyproject.toml" },
+    { file = "src/**/*.{h,c,hpp,cpp}" },
+    { file = "CMakeLists.txt" },
+]
+
 [tool.ruff]
 line-length = 120
 


### PR DESCRIPTION
Super cool stuff!

I was bored and going through the release notes of uv [0.8.18](https://github.com/astral-sh/uv/releases/tag/0.8.18). I noticed PR 15705, and it’s so cool!

Basically, it rebuilds the project if C++ files are changed. I’ve always found it frustrating that, in order to test the C++ changes I made, I had to run `uv pip install -e . && uv run pytest`.

Now it’s just `uv run pytest`.

Ta-da!