### PR TITLE
Fix pessimist-add measure tests

### DIFF
--- a/tests/test_measures.py
+++ b/tests/test_measures.py
@@ -87,7 +87,6 @@ def test_pessimist_add_measure(seed, rule, rule_measure):
                     na.remove(project)
             if ok:
                 assert result == expected_result
-                assert 1 <= result <= len(non_approvers)
                 return
         assert result is None
 


### PR DESCRIPTION
The definition of the pessimist-add measure I implemented for testing in #57 was slightly different (read: messed up). Fixed it.

Painfully enough, the two definitions coincide in most cases.