### PR TITLE
Test multiple Python versions in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ '3.10', '3.13' ]
+        python-version: [ '3.10', '3.11', '3.12', '3.13' ]
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-python@v6


### PR DESCRIPTION
Since the development is almost finished, and we plan to release it, I'd be good to test as much is possible. Sadly, we can't do this now on Windows because we need to install OR-Tools in GH Actions.