### PR TITLE
Fix authors metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,8 +4,8 @@ version = "0.1.0"
 description = "Measures on participatory budgeting elections"
 readme = "README.md"
 authors = [
-    { name = "Michał Dobranowski", email = "mdbrnowski@gmail.com" },
-    { name = "Jakub Wiśniewski", email = "wisniewskij514@gmail.com" },
+    { name = "Michał Dobranowski" },
+    { name = "Jakub Wiśniewski" },
 ]
 license = "MIT"
 license-files = ["LICENSE"]


### PR DESCRIPTION
`scikit-build-core` incorrectly handles authors metadata when it contains emails, creating
```
Author-Email: =?utf-8?q?Micha=C5=82_Dobranowski?= <mdbrnowski@gmail.com>, =?utf-8?q?Jakub_Wi=C5=9Bniewski?= <wisniewskij514@gmail.com>
```
instead of
```
Author-email: Michał Dobranowski <mdbrnowski@gmail.com>, Jakub Wiśniewski <wisniewskij514@gmail.com>
```
like e.g. [hatchling](https://pypi.org/project/hatchling/) do.

We should raise an issue at https://github.com/scikit-build/scikit-build-core, but for now let's just remove emails.